### PR TITLE
Refactor readFREDStat to improve tracking rate extraction. Before I w…

### DIFF
--- a/fredtools/ft_simTools.py
+++ b/fredtools/ft_simTools.py
@@ -159,7 +159,8 @@ def readFREDStat(fileNameLogOut, displayInfo=False):
     simInfo["primarySimulated"] = float(matchData(r"Number of primary particles", rf"Number of primary particles:\W+({ft.re_number})"))
     simInfo["primarySimulated"] = int(simInfo["primarySimulated"]) if not np.isnan(simInfo["primarySimulated"]) else np.nan
 
-    simInfo["trackingRate_prim_s"] = float(matchData(r"Tracking rate", rf"Tracking rate:\W+({ft.re_number})"))
+    lineFromFile = ft.getLineFromFile('Tracking rate:', fileNameLogOut, kind="first")
+    simInfo["trackingRate_prim_s"] = float(re.search(r"Tracking rate:\s+([0-9.eE+-]+)\s+primary/s", lineFromFile[1]).group(1))
     simInfo["trackingRate_prim_s"] = int(simInfo["trackingRate_prim_s"]) if not np.isnan(simInfo["trackingRate_prim_s"]) else np.nan
 
     simInfo["trackTimePerPrimary_us"] = float(matchData(r"Track time per primary", rf"Track time per primary:\W+({ft.re_number})"))


### PR DESCRIPTION
I got NAN every time I set displayInfo=True on runFRED function. The issue was the parsing of the line 'Tracking rate: ...' from the fred log data. I have modified the function readFREDStat in order to get the tracking rate correctly. Tested on FRED v3.71.0 of Windows 10.
Before:
![image](https://github.com/user-attachments/assets/fedc8786-1881-428c-af8d-277461d0930d)
After:
![image](https://github.com/user-attachments/assets/eb62fa45-055d-4aee-bc80-ee8ce9f3e58d)

